### PR TITLE
Fixed bug not linking to CSS file

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
     <title>Color Switcher App</title>
 </head>
 


### PR DESCRIPTION
Changed `"/style.ss"` to `"./style.css"` in HTML link to CSS file.